### PR TITLE
Fix service worker paths for subdirectory deployment

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1082,7 +1082,7 @@ class ShedOrganizer {
 
     initializeServiceWorker() {
         if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register('/sw.js')
+            navigator.serviceWorker.register('./sw.js')
                 .then(registration => {
                     console.log('SW registered:', registration);
                 })

--- a/sw.js
+++ b/sw.js
@@ -1,12 +1,12 @@
 const CACHE_NAME = 'shed-organizer-cache-v1';
 const urlsToCache = [
-  '/',
-  '/index.html',
-  '/style.css',
-  '/js/app.js',
-  '/js/config.js',
-  '/icon.svg',
-  '/manifest.json'
+  './',
+  'index.html',
+  'style.css',
+  'js/app.js',
+  'js/config.js',
+  'icon.svg',
+  'manifest.json'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- register the service worker using a relative path
- cache assets in the service worker with relative paths so the PWA works in subdirectories

## Testing
- `node --check js/app.js`
- `node --check sw.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897bbe34da883289e361578aad0a8d9