### PR TITLE
Fix service worker registration path for local builds

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1082,7 +1082,7 @@ class ShedOrganizer {
 
     initializeServiceWorker() {
         if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register('/sw.js')
+            navigator.serviceWorker.register('./sw.js')
                 .then(registration => {
                     console.log('SW registered:', registration);
                 })


### PR DESCRIPTION
## Summary
- Use relative path `./sw.js` when registering the service worker to ensure it loads correctly in local builds.

## Testing
- `python3 -m http.server` & `curl -I http://localhost:8000/sw.js`


------
https://chatgpt.com/codex/tasks/task_e_6897bcb18fe48328a989614086a10a12