### PR TITLE
Restrict touch listeners to interactive grid

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -94,14 +94,15 @@ class ShedOrganizer {
         // 3D controls
         this.setup3DControls();
 
-        // Prevent default touch behaviors that interfere with our custom handling
-        document.addEventListener('touchstart', (e) => {
-            if (e.target.closest('.shed-grid, .storage-unit, .tool-item')) {
+        // Prevent default touch behaviors only within the grid area
+        const grid = document.getElementById('shedGrid');
+        grid.addEventListener('touchstart', (e) => {
+            if (e.target.closest('.grid-cell')) {
                 e.preventDefault();
             }
         }, { passive: false });
 
-        document.addEventListener('touchmove', (e) => {
+        grid.addEventListener('touchmove', (e) => {
             if (this.isDragging) {
                 e.preventDefault();
             }


### PR DESCRIPTION
## Summary
- Limit global touch interception by moving touchstart and touchmove handlers from `document` to the grid element
- Allow default scrolling outside interactive regions while still blocking undesired scrolling during drags

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897be51b6fc83288611e52d221c7431