### PR TITLE
Improve accessibility for tool categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,9 +114,9 @@
                         <div class="category-header">
                             <span class="category-icon">🔨</span>
                             <span class="category-name">Hand Tools</span>
-                            <button class="category-toggle">▼</button>
+                            <button class="category-toggle" aria-controls="hand-tools-panel" aria-expanded="false">▼</button>
                         </div>
-                        <div class="category-tools">
+                        <div id="hand-tools-panel" class="category-tools">
                             <div class="tool-item" data-tool="hammer">
                                 <span class="tool-icon">🔨</span>
                                 <span class="tool-name">Hammer</span>
@@ -152,9 +152,9 @@
                         <div class="category-header">
                             <span class="category-icon">⚡</span>
                             <span class="category-name">Power Tools</span>
-                            <button class="category-toggle">▶</button>
+                            <button class="category-toggle" aria-controls="power-tools-panel" aria-expanded="false">▶</button>
                         </div>
-                        <div class="category-tools hidden">
+                        <div id="power-tools-panel" class="category-tools hidden">
                             <div class="tool-item" data-tool="drill">
                                 <span class="tool-icon">🔩</span>
                                 <span class="tool-name">Drill</span>
@@ -190,9 +190,9 @@
                         <div class="category-header">
                             <span class="category-icon">🔧</span>
                             <span class="category-name">Plumbing</span>
-                            <button class="category-toggle">▶</button>
+                            <button class="category-toggle" aria-controls="plumbing-panel" aria-expanded="false">▶</button>
                         </div>
-                        <div class="category-tools hidden">
+                        <div id="plumbing-panel" class="category-tools hidden">
                             <div class="tool-item" data-tool="pipe_wrench">
                                 <span class="tool-icon">🔧</span>
                                 <span class="tool-name">Pipe Wrench</span>
@@ -216,9 +216,9 @@
                         <div class="category-header">
                             <span class="category-icon">⚡</span>
                             <span class="category-name">Electrical</span>
-                            <button class="category-toggle">▶</button>
+                            <button class="category-toggle" aria-controls="electrical-panel" aria-expanded="false">▶</button>
                         </div>
-                        <div class="category-tools hidden">
+                        <div id="electrical-panel" class="category-tools hidden">
                             <div class="tool-item" data-tool="wire">
                                 <span class="tool-icon">⚡</span>
                                 <span class="tool-name">Wire</span>

--- a/js/app.js
+++ b/js/app.js
@@ -494,9 +494,11 @@ class ShedOrganizer {
         if (tools.classList.contains('hidden')) {
             tools.classList.remove('hidden');
             toggle.textContent = '▼';
+            toggle.setAttribute('aria-expanded', 'true');
         } else {
             tools.classList.add('hidden');
             toggle.textContent = '▶';
+            toggle.setAttribute('aria-expanded', 'false');
         }
     }
 


### PR DESCRIPTION
## Summary
- Add IDs and aria attributes linking category toggles to their tool panels
- Toggle `aria-expanded` state when showing or hiding categories

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897be51f6fc8328a1068fd8851c8801